### PR TITLE
Meta viewport tag

### DIFF
--- a/2012/index.html
+++ b/2012/index.html
@@ -25,7 +25,7 @@
     <script src="../media/2012/js/jquery.event.frame.js"></script>
     <link href='http://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
 
-	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel='stylesheet' media="screen and (max-width: 900px)" href='../media/2012/css/moobile.css' />
 
     <link href="../media/2012/bootstrap/css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
The responsive CSS does not work on N9 browser/Android Chrome. The devices scale down the original site instead of utilizing the responsive CSS. Meta viewport tag does the trick, it tells the browser not to scale the content down.
